### PR TITLE
feat(semantic-release): add analyzeCommits step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.1.0](https://github.com/JuroOravec/semantic-release-changelog-update/compare/v1.0.0...v1.1.0) (2020-04-26)
+
+
+### Features
+
+* **semantic-release:** add analyzeCommits step ([24ddc13](https://github.com/JuroOravec/semantic-release-changelog-update/commit/24ddc13e662f6cf0f4cacd413a4a35faa9caaf6a))
+
 # 1.0.0 (2020-04-26)
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ To use outside CI environment, specify both `headBranch` and `baseBranch` option
 ### Requirements
 
 - `git` cli with the permission to push and commit to remote
-- `@semantic-release/commit-analyzer` if used as a plugin.
 
 ### Installation
 
@@ -144,16 +143,13 @@ The function accepts an object with 3 properties:
 Add the plugin to
 [semantic-release config](https://github.com/semantic-release/semantic-release/blob/431d571a7b7284b2029a55da68a44c65d7c16451/docs/usage/configuration.md#plugins).
 
-The plugin must go _before_ `@semantic-release/commit-analyzer` to work properly.
-
 ```json
 {
   "dryRun": true,
   "ci": false,
   ...
   "plugins": [
-    "semantic-release-changelog-update/plugin",
-    "@semantic-release/commit-analyzer"
+    "semantic-release-changelog-update/plugin"
   ]
 }
 ```
@@ -168,7 +164,6 @@ module.exports = {
   ....
   plugins: [
     changelogUpdate.plugin,
-    "@semantic-release/commit-analyzer"
   ]
 }
 ```
@@ -185,8 +180,7 @@ You can pass [options](#options) like this:
         "message": "custom commit message",
         "prepareChangelog": "./path/to/func"
       }
-    ],
-    "@semantic-release/commit-analyzer"
+    ]
   ]
 }
 ```
@@ -218,9 +212,10 @@ The plugin additionally accepts options that are passed to other plugin it uses:
 
 | Plugin                                                                                                                                                               | Notes                                                            |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [@semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/tree/2b9c73e1b4d63221980da18fd3d1f2817aaee1b8#configuration)                 | All options are passed forward.                                  |
+| [@semantic-release/release-notes-generator](https://github.com/semantic-release/release-notes-generator/tree/a0f6c8941c38ed884546b03f51a71a3f6fc1c665#configuration) | All options are passed forward.                                  |
 | [@semantic-release/git](https://github.com/semantic-release/git/tree/905f113a577c55cd9bb0a37ea3504d9e8ee2dfa2#options)                                               | The `assets` option is ignored and overriden by `changelogFile`. |
 | [@semantic-release/changelog](https://github.com/semantic-release/changelog/tree/bede4d04b0a9ec13a5661bf0424465176486f3fd#options)                                   | All options are passed forward.                                  |
-| [@semantic-release/release-notes-generator](https://github.com/semantic-release/release-notes-generator/tree/a0f6c8941c38ed884546b03f51a71a3f6fc1c665#configuration) | All options are passed forward.                                  |
 
 ## 🔮 Details
 
@@ -238,12 +233,20 @@ The plugin additionally accepts options that are passed to other plugin it uses:
 
 In the background, this plugin does the following:
 
-- Creates a temporary branch named `temp/semantic-release/<branch-name>`. This branch is based on `baseBranch` with commits rebased from
+- Creates a temporary branch named `temp/semantic-release/<branch-name>`. This
+  branch is based on `baseBranch` with commits rebased from
   `headBranch` on top of it, so we have a branch that contains all
   (current + new) commits without polluting any working branches.
-- The temporary branch is pushed to remote so `commit-analyzer` can find it and extract commits.
-- After `commit-analyzer`, the plugin calls `release-notes-generator`, `changelog` and `git` passing the temporary branch as the branch these plugins should work against. This updates the changelog and pushes it to the temporary branch.
-- Lastly, the commit containing the changelog update is pushed to the `headBranch` and the temporary branch is removed.
+- The temporary branch is pushed to remote so `commit-analyzer` can find it
+  and extract commits.
+- If `commit-analyzer` found no release-worthy commits, the temporary branch
+  is removed and the `semantic-release` end the pipeline.
+- After `commit-analyzer`, the plugin calls `release-notes-generator`,
+  `changelog` and `git` passing the temporary branch as the branch these
+  plugins should work against. This updates the changelog and pushes it to
+  the temporary branch.
+- Lastly, the commit containing the changelog update is pushed to the
+  `headBranch` and the temporary branch is removed.
 
 ## ⏳ Changelog
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   },
   "dependencies": {
     "@semantic-release/changelog": "^5.0.1",
+    "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/release-notes-generator": "^9.0.1",
     "@types/debug": "^4.1.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export function changelogUpdate({
     ci: false,
     branches: ['**/*'],
     ...options,
-    plugins: [[plugin, plgnOptions], '@semantic-release/commit-analyzer'],
+    plugins: [[plugin, plgnOptions]],
   };
 
   return sr(srOptions, environment);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,5 @@
 import getVerifyConditions from './steps/verify-conditions';
+import getAnalyzeCommits from './steps/analyze-commits';
 import getGenerateNotes from './steps/generate-notes';
 
 // Data shared between functions with default props
@@ -9,5 +10,6 @@ const meta = {};
 
 module.exports = {
   verifyConditions: getVerifyConditions(meta),
+  analyzeCommits: getAnalyzeCommits(meta),
   generateNotes: getGenerateNotes(meta),
 };

--- a/src/steps/analyze-commits.ts
+++ b/src/steps/analyze-commits.ts
@@ -1,0 +1,35 @@
+// @ts-ignore
+import commitAnalyzer from '@semantic-release/commit-analyzer';
+
+import type { Context, Config, Meta } from '../types';
+
+import cleanup from '../lib/cleanup';
+
+/**
+ * Wrapper around @semantic-release/commit-analyzer so we can remove the
+ * temporary branches if no releaseType is determined (because then the
+ * pipeline ends with the analyze commits step)
+ */
+async function analyzeCommits(
+  pluginConfig: Config,
+  context: Context,
+  meta: Meta = {},
+) {
+  const releaseType = await commitAnalyzer.analyzeCommits(
+    pluginConfig,
+    context,
+  );
+  if (!releaseType) {
+    await cleanup(pluginConfig, context, meta);
+  }
+  return releaseType as string | null;
+}
+
+export default function getAnalyzeCommits(meta: Meta = {}) {
+  return async function analyzeCommitsWrapper(
+    pluginConfig: Config,
+    context: Context,
+  ) {
+    return analyzeCommits(pluginConfig, context, meta);
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ import type {
   ChangelogConfig,
   GenerateReleaseNotesConfig,
   GitConfig,
+  CommitAnalyzerConfig,
 } from './plugins';
 
 type BranchArg = string | Branch;
@@ -30,6 +31,7 @@ export type Config = Partial<GlobalConfig> &
   Partial<ChangelogConfig> &
   Partial<GenerateReleaseNotesConfig> &
   Partial<GitConfig> &
+  Partial<CommitAnalyzerConfig> &
   Partial<{
     pattern: string | RegExp;
     baseBranch: string;

--- a/src/types/plugins.ts
+++ b/src/types/plugins.ts
@@ -119,3 +119,50 @@ export type GenerateReleaseNotesConfig = {
    */
   presetConfig: any;
 };
+
+/**
+ * Options passed to `@semantic-release/commit-analyzer`
+ *
+ * See `@semantic-release/commit-analyzer`
+ *
+ * Generated from v8.0.1
+ */
+export type CommitAnalyzerConfig = {
+  /**
+   * conventional-changelog preset.
+   *
+   * See `@semantic-release/commit-analyzer` option `preset`
+   */
+  preset: string;
+  /**
+   * NPM package name of a custom conventional-changelog preset.
+   *
+   * See `@semantic-release/commit-analyzer` option `config`
+   */
+  config: string;
+  /**
+   * Additional conventional-commits-parser options that will extends the ones
+   * loaded by preset or config. This is convenient to use a
+   * conventional-changelog preset with some customizations without having to
+   * create a new module.
+   *
+   * See `@semantic-release/commit-analyzer` option `parserOpts`
+   */
+  parserOpts: any;
+  /**
+   * Additional conventional-commits-writer options that will extends the ones
+   * loaded by preset or config. This is convenient to use a
+   * conventional-changelog preset with some customizations without having to
+   * create a new module.
+   *
+   * See `@semantic-release/commit-analyzer` option `writerOpts`
+   */
+  writerOpts: any;
+  /**
+   * Additional configuration passed to the conventional-changelog preset. Used
+   * for example with conventional-changelog-conventionalcommits.
+   *
+   * See `@semantic-release/commit-analyzer` option `presetConfig`
+   */
+  presetConfig: any;
+};


### PR DESCRIPTION
the step wraps @semantic-release/commit-analyzer so we can remove our temporary branches if no
release type is determined. This is because in this case, the semantic-release pipeline ends at this
point, so we won't get to generateNotes step. But if we won't get there, then until now the
temporary branches were not removed.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

### Pull Request Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/JuroOravec/semantic-release-changelog-update/blob/master/docs/CONTRIBUTING.md) doc

- [x] Tests for the changes have been added and are passing (for bug fixes / features). The tests should fail without the change.

- [x] Docs / README have been reviewed and added / updated if needed (for bug fixes / features)

- [x] Code compiles correctly

- [x] Build was run locally and any changes were pushed

- [x] Lint has passed locally and any fixes were pushed

- [x] The commits' message styles match our requested structure.

- [x] Added myself / the copyright holder to the AUTHORS file

### Pull Request Type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

<!-- Please check the type of change your PR introduces: -->

- [ ] Bugfix

- [x] Feature

- [ ] Code style update (formatting, renaming)

- [ ] Refactoring (no functional changes, no api changes)

- [ ] Build related changes

- [ ] CI related changes

- [ ] Documentation content changes

- [ ] Other (please describe):

### Issue Number

<!-- Provide issue number in the form #1234. This is required to pass. If this PR doesn't relate to any issues, keep 'no-issue' -->

no-issue

### Current Behavior

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If the plugin is used when @semantic-release/commit-analyzer doesn't detect any release type, the semantic-release pipeline ends right there. That means that the temporary branch create before that doesn't get the chance to be removed.

### New Behavior

<!-- Please describe the behavior or changes that are being added by this PR. -->

The analyzeCommits step wraps @semantic-release/commit-analyzer so we can remove our temporary branches if no
release type is determined. This is because in this case, the semantic-release pipeline ends at this
point, so we won't get to generateNotes step. But if we won't get there, then until now the
temporary branches were not removed.

### Does this introduce a breaking change?

<!-- Put an `x` in the boxes that apply -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

<!-- If this is a relatively large or complex change, you can kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

<!-- Thank you! -->
