### PR TITLE
Fix debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.7](https://github.com/JuroOravec/semantic-release-changelog-update/compare/v1.1.6...v1.1.7) (2020-05-03)
+
+
+### Bug Fixes
+
+* **logging:** fix package name detection by debug ([3fc932b](https://github.com/JuroOravec/semantic-release-changelog-update/commit/3fc932b052898373325759624116e06a07a58be6))
+
 ## [1.1.6](https://github.com/JuroOravec/semantic-release-changelog-update/compare/v1.1.5...v1.1.6) (2020-04-27)
 
 ## [1.1.5](https://github.com/JuroOravec/semantic-release-changelog-update/compare/v1.1.4...v1.1.5) (2020-04-27)

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -2,7 +2,8 @@ import debug from 'debug';
 import readPkgUp from 'read-pkg-up';
 
 function getDebugLogger() {
-  const { packageJson: { name = '' } = {} } = readPkgUp.sync() || {};
+  const { packageJson: { name = '' } = {} } =
+    readPkgUp.sync({ cwd: module.filename }) || {};
   if (!name) {
     console.warn(
       'Cannot find package name, using console.log instead of debug package',

--- a/src/lib/debug.ts
+++ b/src/lib/debug.ts
@@ -1,4 +1,4 @@
-import debug from 'debug';
+import debugPkg from 'debug';
 import readPkgUp from 'read-pkg-up';
 
 function getDebugLogger() {
@@ -10,9 +10,9 @@ function getDebugLogger() {
     );
     return console.log;
   }
-  return debug(name);
+  return debugPkg(name);
 }
 
-const mainDebug = getDebugLogger();
+const debug = getDebugLogger();
 
-export default mainDebug;
+export default debug;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->

### Pull Request Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING](https://github.com/JuroOravec/semantic-release-changelog-update/blob/master/docs/CONTRIBUTING.md) doc

- [x] Tests for the changes have been added and are passing (for bug fixes / features). The tests should fail without the change.

- [x] Docs / README have been reviewed and added / updated if needed (for bug fixes / features)

- [x] Code compiles correctly

- [x] Build was run locally and any changes were pushed

- [x] Lint has passed locally and any fixes were pushed

- [x] The commits' message styles match our requested structure.

- [x] Added myself / the copyright holder to the AUTHORS file

### Pull Request Type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

<!-- Please check the type of change your PR introduces: -->

- [x] Bugfix

- [ ] Feature

- [ ] Code style update (formatting, renaming)

- [ ] Refactoring (no functional changes, no api changes)

- [ ] Build related changes

- [ ] CI related changes

- [ ] Documentation content changes

- [ ] Other (please describe):

### Issue Number

<!-- Provide issue number in the form #1234. This is required to pass. If this PR doesn't relate to any issues, keep 'no-issue' -->

no-issue

### Current Behavior

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

### New Behavior

1) fix package name detection by debug.

currently the working dirctory for detecting the name of the package that should be used in debug
package was set to current working directory. This worked fine when working in the package itself,
but when the package was imported, the cwd pointed elsewhere, and so all debug statements of the
first package were included in the cwd's package's debug statements too.

This commit fixes that
by specifying to search for the package name in the directory where the file that creates the debug
instance is located. So even if the package is imported, the imported package's directory is
searched, not the importee's directory.

2) rename debug export from mainDebug to debug, so intellisense suggest local debug

### Does this introduce a breaking change?

<!-- Put an `x` in the boxes that apply -->

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

<!-- If this is a relatively large or complex change, you can kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

<!-- Thank you! -->
